### PR TITLE
Reduce duplicated content between class 4 & 5

### DIFF
--- a/class3.html
+++ b/class3.html
@@ -667,20 +667,6 @@
         </section>
 
         <section>
-          <h2>Think inside the box</h2>
-          <img src="images/css-box-model/instagram-website.png"
-               alt="Instagram website">
-          <p class="footnote">Image from instagram.com</p>
-        </section>
-
-        <section>
-          <h2>Think inside the box</h2>
-          <img src="images/css-box-model/instagram-website-layout.png"
-               alt="The instagram website sectioned into boxes.">
-          <p class="footnote">Image from instagram.com</p>
-        </section>
-
-        <section>
           <h2>Let's Code: Block and Inline Elements</h2>
           <p>Replace existing HTML with the following:</p>
 

--- a/class4.html
+++ b/class4.html
@@ -40,16 +40,6 @@
         </section>
 
         <section>
-          <h2>
-            <a href="https://www.sli.do" target="_blank">
-              Ask Questions with Sli.do
-            </a>
-          </h2>
-
-          <p>The event code will be announced.</p>
-        </section>
-
-        <section>
           <h2>Today</h2>
           <ul>
             <li>Review</li>
@@ -129,7 +119,7 @@
           <h2>Setup a Coding Environment</h2>
           <p>We will need:</p>
           <ul>
-            <li>Atom -  text editor used to write code</li>
+            <li>Atom - text editor used to write code</li>
             <li>Chrome - browser to render our website</li>
             <li>A project folder</li>
             <li>An HTML file</li>
@@ -573,11 +563,20 @@
         </section>
 
         <section>
+          <h2>Build a Website</h2>
+
+          <p>
+            Part of building a website includes ensuring everyone can access
+            the website. For this, we'll need to use a company that offers web
+            hosting.
+          </p>
+        </section>
+
+        <section>
           <h2>Web Hosting</h2>
           <p>
-            A service that stores website files (ie: index.html and
-            styles.css)<br>
-            so a website is accessible via the internet.
+            A service that stores all the necessary files to render your
+            website. This includes the index.html and styles.css files.
           </p>
 
           <ul>
@@ -619,12 +618,10 @@
             Neocities offers an
             <a href="https://neocities.org/tutorial/html/1">HTML tutorial</a>
           </p>
-
-          <p class="fragment">Edit the default website</p>
         </section>
 
         <section>
-          <h2>Final Project - Getting Started</h2>
+          <h2>Let's Get Started</h2>
           <p>
             Clear out the existing HTML but keep the HTML
             <strong>structure</strong>.
@@ -635,7 +632,7 @@
               &lt;!DOCTYPE html&gt;
               &lt;html&gt;
                 &lt;head&gt;
-                  <title>Beachadventures</title>
+                  <title>your-website-name</title>
                   <link href="/style.css" rel="stylesheet" type="text/css"
                         media="all">
                 &lt;/head&gt;
@@ -648,163 +645,54 @@
         </section>
 
         <section>
-          <h2>Add Intro Content</h2>
+          <h2>Set the browser tab Title</h2>
+
+          <pre>
+            <code class="html" data-trim contenteditable>
+              &lt;head&gt;
+                <title>your-website-name</title>
+              &lt;/head&gt;
+            </code>
+          </pre>
+        </section>
+
+        <section>
+          <h2>Add the Nav Content</h2>
           <p>
-            In the HTML file, inside the &lt;body&gt; tags, add the following:
+            A large number of sites use "lists" to create their navigation or
+            footer as these section are a collection of links.
           </p>
 
           <pre>
             <code class="html" data-trim contenteditable>
-              <p>Welcome!</p>
-              <h1>Somewhere on a Beach</h1>
+              <nav>
+                <ul>
+                  <li>Home</li>
+                  <li>Posts</li>
+                </ul>
+              </nav>
             </code>
           </pre>
         </section>
 
         <section>
-          <h2>Styling the Intro</h2>
-          <p>To style our HTML, we need a way for the CSS to target our HTML.</p>
-          <p>Let's add classes for this purpose:</p>
+          <h2>Turn the Nav Text into Links</h2>
+
+          <p>Wrap each list item in a link:</p>
 
           <pre>
             <code class="html" data-trim contenteditable>
-              <p class="intro">Welcome!</p>
-              <h1 class="intro-about">Somewhere on a Beach</h1>
-            </code>
-          </pre>
-        </section>
+              <nav>
+                <ul>
+                  <li>
+                    <a href="#">Home</a>
+                  </li>
 
-        <section>
-          <h2>Styling the Intro</h2>
-          <p>Goal: reduce the space between the lines of content</p>
-
-          <pre>
-            <code class="css" data-trim contenteditable>
-              .intro {
-                margin-bottom: 5px;
-              }
-
-              .intro-about {
-                margin: 0;
-                font-size: 28px;
-              }
-            </code>
-          </pre>
-        </section>
-
-        <section>
-          <h2>Style the Intro</h2>
-          <p>Goal: Center the text.</p>
-          <p>Hint: Add a div and class to target both elements</p>
-
-          <pre>
-            <code class="html" data-trim contenteditable>
-              <div class="intro-section">
-                <p class="intro">Welcome!</p>
-                <h1 class="intro-about">Somewhere on a Beach</h1>
-              </div>
-            </code>
-          </pre>
-        </section>
-
-        <section>
-          <h2>Style the Intro</h2>
-          <p>Goal: Center the text.</p>
-          <p>
-            Hint: Use the recently added class to set the text-align property.
-          </p>
-
-          <pre>
-            <code class="css" data-trim contenteditable>
-              .intro-section {
-                text-align: center;
-               }
-            </code>
-          </pre>
-        </section>
-
-        <section>
-          <h2>Style the Intro</h2>
-          <p>Goal: Give the Intro section space.</p>
-          <p>
-            Hint: Add another div (or "box") that wraps the inner content.
-          </p>
-
-          <pre>
-            <code class="html" data-trim contenteditable>
-              <div class="intro-container">
-                <div class="intro-section">
-                  <p class="intro">Welcome!</p>
-                  <h1 class="intro-about">Somewhere on a Beach</h1>
-                </div>
-              </div>
-            </code>
-          </pre>
-        </section>
-
-        <section>
-          <h2>Style the Intro</h2>
-          <p>Goal: Give the Intro section space.</p>
-          <p>
-            Hint: Use the recently added class to set the height property.
-          </p>
-
-          <pre>
-            <code class="css" data-trim contenteditable>
-              .intro-container {
-                height: 200px;
-                background-color: grey;
-               }
-
-              .intro-section {
-                padding-top: 60px
-              }
-            </code>
-          </pre>
-        </section>
-
-        <section>
-          <h2>Style the Intro</h2>
-          <p>Goal: Center the text vertically</p>
-          <p>
-            Hint: Use an existing class to set the padding-top property.
-          </p>
-
-          <pre>
-            <code class="css" data-trim contenteditable>
-              .intro-section {
-                padding-top: 60px
-              }
-            </code>
-          </pre>
-        </section>
-
-        <section>
-          <h2>Add an Image</h2>
-          <p>
-            To add an image, we'll use the background-image CSS property but
-            we'll need some HTML so the CSS has an element to target.
-          </p>
-
-          <pre>
-            <code class="html" data-trim contenteditable>
-              <div class="hero"></div>
-            </code>
-          </pre>
-        </section>
-
-        <section>
-          <h2>Add an Image</h2>
-
-          <pre>
-            <code class="css" data-trim contenteditable>
-              .hero {
-                background-image: url("watermelon.jpg");
-                background-position: center;
-                background-repeat: no-repeat;
-                background-size: cover;
-                height: 700px;
-              }
+                  <li>
+                    <a href="#">Posts</a>
+                  </li>
+                </ul>
+              </nav>
             </code>
           </pre>
         </section>

--- a/class5.html
+++ b/class5.html
@@ -96,11 +96,10 @@
         </section>
 
         <section>
-          <h2>Setup a Coding Environment</h2>
-          <p>We will need:</p>
+          <h2>Coding Environment Setup</h2>
           <ul>
-            <li>Atom -  text editor used to write code</li>
-            <li>Chrome - browser to render our website</li>
+            <li>A text editor used to write code (Atom)</li>
+            <li>A browser to render the website (Chrome)</li>
             <li>A project folder</li>
             <li>An HTML file</li>
             <li>A CSS file</li>
@@ -108,81 +107,14 @@
         </section>
 
         <section>
-          <h2>Final Prject - Let's Dive In!</h2>
+          <h2>Final Project - Let's Dive In!</h2>
           <ol>
-            <li>Tab Title</li>
             <li>Nav</li>
             <li>Header</li>
             <li>Image</li>
             <li>Blog Posts</li>
             <li>Responsive</li>
           </ol>
-        </section>
-
-        <section>
-          <h2>Add the HTML structure</h2>
-
-          <pre>
-            <code data-trim contenteditable>
-              &lt;!DOCTYPE html&gt;
-              &lt;html&gt;
-                &lt;head&gt;
-                &lt;/head&gt;
-
-                &lt;body&gt;
-                &lt;/body&gt;
-              &lt;/html&gt;
-            </code>
-          </pre>
-        </section>
-
-        <section>
-          <h2>Set the browser tab Title</h2>
-
-          <pre>
-            <code class="html" data-trim contenteditable>
-              &lt;head&gt;
-                <title>Beach Adventures</title>
-              &lt;/head&gt;
-            </code>
-          </pre>
-        </section>
-
-        <section>
-          <h2>Add the Nav Content</h2>
-          <p>
-            A large number of sites use "lists" to create their navigation or
-            footer as these section are a collection of links.
-          </p>
-
-          <pre>
-            <code class="html" data-trim contenteditable>
-              <ul>
-                <li>Home</li>
-                <li>Posts</li>
-              </ul>
-            </code>
-          </pre>
-        </section>
-
-        <section>
-          <h2>Turn the Nav Text into Links</h2>
-
-          <p>Wrap each list item in a link:</p>
-
-          <pre>
-            <code class="html" data-trim contenteditable>
-              <ul>
-                <a href="#">
-                  <li>Home</li>
-                </a>
-
-                <a href="#">
-                  <li>Posts</li>
-                </a>
-              </ul>
-            </code>
-          </pre>
         </section>
 
         <section>
@@ -199,25 +131,6 @@
               .nav-list {
                 list-style-type: none;
               }
-            </code>
-          </pre>
-        </section>
-
-        <section>
-          <h2>Link the Stylesheet to the HTML Document</h2>
-          <p>This tells the HTML document to use the referenced stylesheet.</p>
-
-          <pre>
-            <code class="html" data-trim contenteditable>
-              &lt;!DOCTYPE html&gt;
-              &lt;html&gt;
-                &lt;head&gt;
-                  <link rel="stylesheet" type="text/css" href="styles.css">
-                &lt;/head&gt;
-
-                &lt;body&gt;
-                &lt;/body&gt;
-              &lt;/html&gt;
             </code>
           </pre>
         </section>
@@ -267,9 +180,9 @@
           <pre>
             <code class="css" data-trim contenteditable>
               .nav-list {
-                list-style-type: none;
                 display: flex; /* new */
                 flex-direction: row; /* new */
+                list-style-type: none;
               }
             </code>
           </pre>
@@ -441,7 +354,7 @@
           <p>Goal: Increase the size of the Intro section.</p>
 
           <pre>
-            <code class="html" data-trim contenteditable>
+            <code class="css" data-trim contenteditable>
               .intro-section {
                 padding-top: 50px;
                 padding-bottom: 50px;
@@ -504,7 +417,7 @@
         </section>
 
         <section>
-          <h2>Add our first blog post</h2>
+          <h2>Create a Blog Post</h2>
           <p>
             Use Lorem Ipsum, also known as "dummy text", to simulate content.
             Visit <a href="https://www.lipsum.com">https://www.lipsum.com</a> to
@@ -522,7 +435,7 @@
         </section>
 
         <section>
-          <h2>Add a link to the blog post</h2>
+          <h2>Add a Link to the Blog Post</h2>
 
           <pre>
             <code class="html" data-trim contenteditable>
@@ -532,14 +445,14 @@
               <p>Generated Lorem Ipsum...</p>
               <p>
                 Read more about Florida Beaches
-                <a href="#" target="_blank">here</a>.
+                <a href="#">here</a>.
               </p>
             </code>
           </pre>
         </section>
 
         <section>
-          <h2>Thicken the Blog Post Title</h2>
+          <h2>Style the Blog Post Title</h2>
           <p>Add a class to the blog post title.</p>
 
           <pre>
@@ -550,7 +463,7 @@
         </section>
 
         <section>
-          <h2>Thicken the Blog Post Title</h2>
+          <h2>Style the Blog Post Title</h2>
 
           <pre>
             <code class="css" data-trim contenteditable>
@@ -660,73 +573,6 @@
             elements and content, copy all the HTML and paste it below the
             existing article HTML.
           </p>
-        </section>
-
-        <section>
-          <h2>Web Hosting</h2>
-          <p>
-            A service that stores website files (ie: index.html and
-            styles.css)<br>
-            so a website is accessible via the internet.
-          </p>
-
-          <ul>
-            <li>HostGator</li>
-            <li>DreamHost</li>
-            <li>GoDaddy</li>
-            <li>Wix - user-friendly editor</li>
-            <li>Squarespace - user-friendly editor</li>
-          </ul>
-        </section>
-
-        <section>
-          <h2>Web Hosting</h2>
-          <p>
-            For our final project, we'll use the web hosting service Neocities.
-          </p>
-
-          <p class="fragment">Why neocities?</p>
-
-          <ul class="fragment">
-            <li>Free</li>
-            <li>In-browser HTML and CSS editor</li>
-            <li>Easy to save and view changes</li>
-          </ul>
-        </section>
-
-        <section>
-          <h2>Neocities - Getting Started</h2>
-          <p>
-            Visit <a href="https://neocities.org">neocities.org</a> to create an
-            account.
-          </p>
-
-        </section>
-
-        <section>
-          <h2>Explore Neocities</h2>
-          <p class="fragment">
-            Neocities offers an
-            <a href="https://neocities.org/tutorial/html/1">HTML tutorial</a>
-          </p>
-
-          <p class="fragment">Edit the default website</p>
-
-          <aside class="notes">
-            Edit the existing site just to demo how the files work and how to
-            see the site change.
-          </aside>
-        </section>
-
-        <section>
-          <h2>Upload files to Neocities</h2>
-          <p>Clear out the code in the existing HTML and CSS files.</p>
-
-          <ol>
-            <li>Replace the HTML file with the contents in your HTML file.</li>
-            <li>Replace the CSS file with the contents in your CSS file.</li>
-            <li>Upload your hero image.</li>
-          </ol>
         </section>
 
         <section>


### PR DESCRIPTION
Summary:
The slides for Class 4 and Class 5 are jumbled and repetitive in an
unhelpful way. I'm not sure why this was helpful for the first class but
I've opted to reorganize the slides for the next class.

These changes also include a few other small fixes like:
- removes the use of `target="_blank"`
- removes references to sli.do
- reduces the number of website layout examples to just one example