### PR TITLE
Allow reveal.js to scale with browser zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,9 @@
           { src: 'plugin/markdown/markdown.js' },
           { src: 'plugin/notes/notes.js', async: true },
           { src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }
-        ]
+        ],
+        minScale: 1,
+        maxScale: 1
       });
     </script>
   </body>


### PR DESCRIPTION
Reveal.js keeps a consistent size when the browser is zoomed in and
out. It understands what size the viewport is and scales the content
accordingly. Even if you change the zoom level of the browser window.

These are set with minScale and maxScale. This specifies the minimum
and maximum that reveal JS will scale the content to match the zoom
level. By setting these both to 1 it means that the content will always
be at scale(1) and therefore will adjust when the browser is adjusted.

Reference: https://stackoverflow.com/a/16194390